### PR TITLE
Fix resetting/stopping Reconnector, 

### DIFF
--- a/src/reconnector.js
+++ b/src/reconnector.js
@@ -37,7 +37,7 @@ export default function Reconnector(
         } else {
             onReconnectionCountdown(timeToCurrentReconnectionMs);
             timeToCurrentReconnectionMs -= 1000;
-            setTimeout(step, 1000);
+            reconnection = setTimeout(step, 1000);
         }
     };
 


### PR DESCRIPTION
make step timeout clear-able, as reference to it was never stored, and we were resetting something that was always `null`